### PR TITLE
fixed typos in rover_onboard_node_launch.sh

### DIFF
--- a/misc/rover_onboard_node_launch.sh
+++ b/misc/rover_onboard_node_launch.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 pkill usb_cam_node
-pkill behaviour
+pkill behaviours
 pkill obstacle
 pkill apriltag_detector_node
 pkill abridge
@@ -47,7 +47,7 @@ findDevicePath() {
 #Startup ROS packages/processes
 nohup rosrun tf static_transform_publisher __name:=$HOSTNAME\_BASE2CAM 0.12 -0.03 0.195 -1.57 0 -2.22 /$HOSTNAME/base_link /$HOSTNAME/camera_link 100 &
 nohup rosrun usb_cam usb_cam_node __name:=$HOSTNAME\_CAMERA /$HOSTNAME\_CAMERA/image_raw:=/$HOSTNAME/camera/image _camera_info_url:=file://${HOME}/rover_workspace/camera_info/head_camera.yaml _image_width:=320 _image_height:=240 &
-nohup rosrun behaviour behaviour &
+nohup rosrun behaviours behaviours &
 nohup rosrun obstacle_detection obstacle &
 nohup rosrun diagnostics diagnostics &
 


### PR DESCRIPTION
The problem:
    When testing in physical rovers, the rovers would not appear
    in the GUI rover list. Further research indicated that the
    behaviours node was not being launched.

The solution:
    The "behaviours" node was mispelled as "behaviour" in the launch
    script. The typo was corrected in two places.