### PR TITLE
setting for swarmie_msgs in CMake

### DIFF
--- a/src/behaviours/CMakeLists.txt
+++ b/src/behaviours/CMakeLists.txt
@@ -11,6 +11,7 @@ find_package(catkin REQUIRED COMPONENTS
   random_numbers
   tf
   apriltags_ros
+  swarmie_msgs
 )
 
 catkin_package(

--- a/src/rqt_rover_gui/CMakeLists.txt
+++ b/src/rqt_rover_gui/CMakeLists.txt
@@ -32,6 +32,7 @@ find_package(catkin REQUIRED COMPONENTS
   geometry_msgs
   ublox_msgs
   ublox_serialization
+  swarmie_msgs
 )
 
 find_package( Qt5 REQUIRED COMPONENTS Widgets Xml )


### PR DESCRIPTION
There is a compilation issue.  
fatal error: swarmie_msgs/Waypoint.h: No such file or directory

We need to add “swarmie_msgs” into the find_package(catkin REQUIRED COMPONENTS  ) in the CMakeLists.txt under the directories “~/src/behaviours” and “~/src/rqt_rover_gui”.
