### PR TITLE
popout mapframe now has larger text

### DIFF
--- a/src/rqt_rover_gui/src/MapFrame.h
+++ b/src/rqt_rover_gui/src/MapFrame.h
@@ -90,6 +90,7 @@ namespace rqt_rover_gui
 
       // Show a copy of the map in its own resizable window
       void popout();
+      void setPopoutFlag();
 
       ~MapFrame();
 
@@ -103,7 +104,7 @@ namespace rqt_rover_gui
 
         void ReceiveWaypointReached(int);
         void ReceiveCurrentRoverName(QString);
-        
+
     protected:
 
       void paintEvent(QPaintEvent *event);
@@ -123,6 +124,7 @@ namespace rqt_rover_gui
       bool display_encoder_data;
       bool display_global_offset;
       bool display_unique_rover_colors;
+      bool am_I_the_popout_map = false;
 
       QTime frame_rate_timer;
       int frames;
@@ -162,26 +164,26 @@ namespace rqt_rover_gui
       float min_seen_y_when_manual_enabled;
 
       QPoint mouse_pointer_position = QPoint(0,0);
-      
+
       MapData* map_data;
 
       // Map coordinate data
       // Calculate the axis positions
       int map_origin_x = 0;
       int map_origin_y = 0;
-      
+
       int map_width = 0;
-      int map_height = 0; 
-      
-      int map_center_x = 0; 
+      int map_height = 0;
+
+      int map_center_x = 0;
       int map_center_y = 0;
 
       float max_seen_x = -std::numeric_limits<float>::max();
       float max_seen_y = -std::numeric_limits<float>::max();
-      
+
       float min_seen_x = std::numeric_limits<float>::max();
       float min_seen_y = std::numeric_limits<float>::max();
-      
+
       float max_seen_width = -std::numeric_limits<float>::max();
       float max_seen_height = -std::numeric_limits<float>::max();
 
@@ -197,4 +199,3 @@ namespace rqt_rover_gui
 }
 
 #endif // MapFrame_H
-


### PR DESCRIPTION
The look of the MapFrame window has been adjusted in order to
facilitate a larger font size when using the popout window.

    * a larger font is used in the popout window (18 points)
    * the standard window uses the default smaller font for
          readability

The requested changes make it significantly easier to create figures
for use in papers.
